### PR TITLE
Simplify sculpt highlight

### DIFF
--- a/docs/sculpting-highlight.md
+++ b/docs/sculpting-highlight.md
@@ -1,0 +1,44 @@
+# Sculpting Highlight Specification
+
+## Purpose
+
+When sculpting mode is active the cursor should preview the affected surface
+area before applying any changes. The highlight must respond instantly as the
+mouse moves and should accurately represent the subset of triangles that would
+be touched by the on-screen finger or mouse radius.
+
+## Requirements
+
+- The cursor ray must project onto the active mesh and highlight only the
+  front-most surface directly touched by the pointer. Back-facing or occluded
+  triangles must never be highlighted.
+- The radius slider in the sculpt controls (1–100) defines the radius in screen
+  pixels so it approximates a fingertip on touch devices. Because the radius is
+  screen-based, zooming in shrinks the world-space area while zooming out makes
+  it larger.
+- Highlighting is only available when the sculpt controls are visible and a
+  tool is selected; moving the pointer away or hiding the controls removes the
+  highlight.
+
+## Surface Neighborhood
+
+- Each mesh builds a simple adjacency map on the main thread as soon as it
+  loads. The structure records per-vertex neighbors and the triangles touching
+  each vertex.
+- The raycast hit identifies the nearest vertex on the front-most triangle.
+  That vertex becomes the root of a breadth-first search across connected
+  vertices.
+- Vertices are explored only while their world-space distance from the root
+  stays within the projected finger radius. Every triangle touched by the
+  visited vertices becomes part of the highlight.
+- Because the traversal never crosses disjoint surfaces hidden behind the hit
+  triangle, back-facing regions remain excluded without extra occlusion tests.
+
+## Highlight Presentation
+
+- Highlighted triangles are rendered as a translucent overlay mesh that shares
+  the exact triangle positions (transformed into world space) so the highlight
+  hugs the surface.
+- The overlay uses an additive cyan tint with depth testing disabled so it is
+  always visible above the base mesh.
+- When no triangles fall within the radius the overlay disappears completely.

--- a/packages/app/src/sculptStructures.ts
+++ b/packages/app/src/sculptStructures.ts
@@ -1,0 +1,52 @@
+import { BufferAttribute, BufferGeometry } from 'three';
+
+export type SculptAdjacency = {
+  vertexCount: number;
+  triangleCount: number;
+  vertexNeighbors: number[][];
+  vertexTriangles: number[][];
+};
+
+export function buildSculptAdjacency(geometry: BufferGeometry): SculptAdjacency {
+  const positionAttr = geometry.getAttribute('position') as BufferAttribute | undefined;
+  if (!positionAttr) {
+    throw new Error('Missing position attribute for sculpt mesh');
+  }
+  const indexAttr = geometry.getIndex();
+  const triangleCount = indexAttr ? indexAttr.count / 3 : positionAttr.count / 3;
+  const vertexCount = positionAttr.count;
+  const neighborSets: Array<Set<number>> = new Array(vertexCount);
+  const vertexTriangles: number[][] = new Array(vertexCount);
+  for (let i = 0; i < vertexCount; i += 1) {
+    neighborSets[i] = new Set();
+    vertexTriangles[i] = [];
+  }
+  for (let tri = 0; tri < triangleCount; tri += 1) {
+    const base = tri * 3;
+    const a = getTriangleVertexIndex(indexAttr, base + 0);
+    const b = getTriangleVertexIndex(indexAttr, base + 1);
+    const c = getTriangleVertexIndex(indexAttr, base + 2);
+    vertexTriangles[a].push(tri);
+    vertexTriangles[b].push(tri);
+    vertexTriangles[c].push(tri);
+    neighborSets[a].add(b);
+    neighborSets[a].add(c);
+    neighborSets[b].add(a);
+    neighborSets[b].add(c);
+    neighborSets[c].add(a);
+    neighborSets[c].add(b);
+  }
+  return {
+    vertexCount,
+    triangleCount,
+    vertexNeighbors: neighborSets.map((set) => Array.from(set)),
+    vertexTriangles
+  };
+}
+
+function getTriangleVertexIndex(indexAttr: BufferAttribute | null, index: number): number {
+  if (indexAttr) {
+    return Number(indexAttr.getX(index));
+  }
+  return index;
+}


### PR DESCRIPTION
## Summary
- document the new screen-space sculpt radius and the requirement to keep highlights limited to the visible surface
- replace the worker-built KD-tree with a per-mesh adjacency map, screen-space radius projection, and breadth-first traversal that only highlights front-facing triangles
- remove the unused sculpt preparation UI/worker plumbing now that structures build immediately on the main thread

## Testing
- `pnpm --filter app test:config`
- `pnpm --filter app test:assets`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919eddc0af48329b0e31fc51d9e077b)